### PR TITLE
Implement Jumbo AEAD

### DIFF
--- a/include/jumbo.hpp
+++ b/include/jumbo.hpp
@@ -1,0 +1,67 @@
+#pragma once
+#include "aead.hpp"
+
+// Jumbo Authenticated Encryption with Associated Data
+namespace jumbo {
+
+// No. of rounds Spongent-π[176] permutation is applied on state
+constexpr size_t ROUNDS = 90;
+
+// Spongent-π[176] permutation state is 176 -bit wide
+constexpr size_t SLEN = 176;
+
+// Given 16 -bytes secret key, 12 -bytes public message nonce, N -bytes
+// associated data & M -bytes plain text, this routine computes M -bytes
+// encrypted text & 8 -bytes authentication tag, using Jumbo AEAD scheme
+// | M, N >= 0
+//
+// Note, associated data is never encrypted, but only authenticated.
+// Also avoid reusing same nonce under same key.
+//
+// See algorithm 1 of Elephant specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/elephant-spec-final.pdf
+static void
+encrypt(const uint8_t* const __restrict key,   // 128 -bit secret key
+        const uint8_t* const __restrict nonce, // 96 -bit nonce
+        const uint8_t* const __restrict data,  // N -bytes associated data
+        const size_t dlen,                     // len(data) = N | >= 0
+        const uint8_t* const __restrict txt,   // M -bytes plain text
+        uint8_t* const __restrict enc,         // M -bytes encrypted text
+        const size_t ctlen,                    // len(txt) = len(enc) = M | >= 0
+        uint8_t* const __restrict tag          // 64 -bit authentication tag
+)
+{
+  elephant::encrypt<SLEN, ROUNDS>(key, nonce, data, dlen, txt, enc, ctlen, tag);
+}
+
+// Given 16 -bytes secret key, 12 -bytes public message nonce, 8 -bytes
+// authentication tag, N -bytes associated data & M -bytes encrypted text, this
+// routine computes M -bytes plain text & boolean verification flag, using Jumbo
+// AEAD scheme | M, N >= 0
+//
+// Note, M -bytes plain text is released only when authentication passes i.e.
+// boolean verification flag holds truth value. Otherwise one should find zero
+// values in decrypted plain text.
+//
+// See algorithm 2 of Elephant specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/elephant-spec-final.pdf
+static bool
+decrypt(const uint8_t* const __restrict key,   // 128 -bit secret key
+        const uint8_t* const __restrict nonce, // 96 -bit nonce
+        const uint8_t* const __restrict tag,   // 64 -bit authentication tag
+        const uint8_t* const __restrict data,  // N -bytes associated data
+        const size_t dlen,                     // len(data) = N | >= 0
+        const uint8_t* const __restrict enc,   // M -bytes encrypted text
+        uint8_t* const __restrict txt,         // M -bytes plain text
+        const size_t ctlen                     // len(enc) = len(txt) = M | >= 0
+)
+{
+  constexpr size_t a = SLEN;
+  constexpr size_t b = ROUNDS;
+
+  bool f = false;
+  f = elephant::decrypt<a, b>(key, nonce, tag, data, dlen, enc, txt, ctlen);
+  return f;
+}
+
+}

--- a/wrapper/elephant.cpp
+++ b/wrapper/elephant.cpp
@@ -1,4 +1,5 @@
 #include "dumbo.hpp"
+#include "jumbo.hpp"
 
 // Thin C wrapper on top of underlying C++ implementation of Elephant
 // authenticated encryption with associated data, which can be used for
@@ -20,6 +21,28 @@ extern "C"
   );
 
   bool dumbo_decrypt(
+    const uint8_t* const __restrict, // 128 -bit secret key
+    const uint8_t* const __restrict, // 96 -bit nonce
+    const uint8_t* const __restrict, // 64 -bit authentication tag
+    const uint8_t* const __restrict, // N -bytes associated data
+    const size_t, // byte length of associated data = N | >= 0
+    const uint8_t* const __restrict, // M -bytes encrypted text
+    uint8_t* const __restrict,       // M -bytes decrypted text
+    const size_t // byte length of encrypted/ decrypted text = M | >= 0
+  );
+
+  void jumbo_encrypt(
+    const uint8_t* const __restrict, // 128 -bit secret key
+    const uint8_t* const __restrict, // 96 -bit nonce
+    const uint8_t* const __restrict, // N -bytes associated data
+    const size_t, // byte length of associated data = N | >= 0
+    const uint8_t* const __restrict, // M -bytes plain text
+    uint8_t* const __restrict,       // M -bytes encrypted text
+    const size_t,             // byte length of plain/ encrypted text = M | >= 0
+    uint8_t* const __restrict // 64 -bit authentication tag
+  );
+
+  bool jumbo_decrypt(
     const uint8_t* const __restrict, // 128 -bit secret key
     const uint8_t* const __restrict, // 96 -bit nonce
     const uint8_t* const __restrict, // 64 -bit authentication tag
@@ -60,6 +83,35 @@ extern "C"
   )
   {
     using namespace dumbo;
+    return decrypt(key, nonce, tag, data, dlen, enc, txt, ctlen);
+  }
+
+  void jumbo_encrypt(
+    const uint8_t* const __restrict key,   // 128 -bit secret key
+    const uint8_t* const __restrict nonce, // 96 -bit nonce
+    const uint8_t* const __restrict data,  // N -bytes associated data
+    const size_t dlen, // byte length of associated data = N | >= 0
+    const uint8_t* const __restrict txt, // M -bytes plain text
+    uint8_t* const __restrict enc,       // M -bytes encrypted text
+    const size_t ctlen, // byte length of plain/ encrypted text = M | >= 0
+    uint8_t* const __restrict tag // 64 -bit authentication tag
+  )
+  {
+    jumbo::encrypt(key, nonce, data, dlen, txt, enc, ctlen, tag);
+  }
+
+  bool jumbo_decrypt(
+    const uint8_t* const __restrict key,   // 128 -bit secret key
+    const uint8_t* const __restrict nonce, // 96 -bit nonce
+    const uint8_t* const __restrict tag,   // 64 -bit authentication tag
+    const uint8_t* const __restrict data,  // N -bytes associated data
+    const size_t dlen, // byte length of associated data = N | >= 0
+    const uint8_t* const __restrict enc, // M -bytes encrypted text
+    uint8_t* const __restrict txt,       // M -bytes decrypted text
+    const size_t ctlen // byte length of encrypted/ decrypted text = M | >= 0
+  )
+  {
+    using namespace jumbo;
     return decrypt(key, nonce, tag, data, dlen, enc, txt, ctlen);
   }
 }

--- a/wrapper/python/elephant.py
+++ b/wrapper/python/elephant.py
@@ -99,5 +99,77 @@ def dumbo_decrypt(
     return f, dec_
 
 
+def jumbo_encrypt(
+    key: bytes, nonce: bytes, data: bytes, text: bytes
+) -> Tuple[bytes, bytes]:
+    """
+    Encrypts M ( >=0 ) -bytes plain text, with Jumbo AEAD,
+    while using 16 -bytes secret key, 12 -bytes public message nonce &
+    N ( >=0 ) -bytes associated data, while producing M -bytes cipher text
+    & 8 -bytes authentication tag ( in order )
+    """
+    assert len(key) == 16, "Jumbo takes 16 -bytes secret key !"
+    assert len(nonce) == 12, "Jumbo takes 12 -bytes nonce !"
+
+    ad_len = len(data)
+    ct_len = len(text)
+
+    key_ = np.frombuffer(key, dtype=u8)
+    nonce_ = np.frombuffer(nonce, dtype=u8)
+    data_ = np.frombuffer(data, dtype=u8)
+    text_ = np.frombuffer(text, dtype=u8)
+    enc = np.empty(ct_len, dtype=u8)
+    tag = np.empty(8, dtype=u8)
+
+    args = [uint8_tp, uint8_tp, uint8_tp, len_t, uint8_tp, uint8_tp, len_t, uint8_tp]
+    SO_LIB.jumbo_encrypt.argtypes = args
+
+    SO_LIB.jumbo_encrypt(key_, nonce_, data_, ad_len, text_, enc, ct_len, tag)
+
+    enc_ = enc.tobytes()
+    tag_ = tag.tobytes()
+
+    return enc_, tag_
+
+
+def jumbo_decrypt(
+    key: bytes, nonce: bytes, tag: bytes, data: bytes, enc: bytes
+) -> Tuple[bool, bytes]:
+    """
+    Decrypts M ( >=0 ) -bytes cipher text, with Jumbo AEAD,
+    while using 16 -bytes secret key, 12 -bytes public message nonce,
+    8 -bytes authentication tag & N ( >=0 ) -bytes associated data, while
+    producing boolean flag denoting verification status ( which must hold truth
+    value, check before consuming decrypted output bytes ) & M -bytes
+    plain text ( in order )
+
+    If authentication check fails ( i.e. boolean verification flag is false ),
+    decrypted text bytes are zeroed.
+    """
+    assert len(key) == 16, "Jumbo takes 16 -bytes secret key !"
+    assert len(nonce) == 12, "Jumbo takes 12 -bytes nonce !"
+    assert len(tag) == 8, "Jumbo takes 8 -bytes authentication tag !"
+
+    ad_len = len(data)
+    ct_len = len(enc)
+
+    key_ = np.frombuffer(key, dtype=u8)
+    nonce_ = np.frombuffer(nonce, dtype=u8)
+    tag_ = np.frombuffer(tag, dtype=u8)
+    data_ = np.frombuffer(data, dtype=u8)
+    enc_ = np.frombuffer(enc, dtype=u8)
+    dec = np.empty(ct_len, dtype=u8)
+
+    args = [uint8_tp, uint8_tp, uint8_tp, uint8_tp, len_t, uint8_tp, uint8_tp, len_t]
+    SO_LIB.jumbo_decrypt.argtypes = args
+    SO_LIB.jumbo_decrypt.restype = bool_t
+
+    f = SO_LIB.jumbo_decrypt(key_, nonce_, tag_, data_, ad_len, enc_, dec, ct_len)
+
+    dec_ = dec.tobytes()
+
+    return f, dec_
+
+
 if __name__ == "__main__":
     print("Use `elephant` as library module")

--- a/wrapper/python/test_elephant.py
+++ b/wrapper/python/test_elephant.py
@@ -75,5 +75,74 @@ def test_dumbo_kat():
             fd.readline()
 
 
+def test_jumbo_kat():
+    """
+    Tests functional correctness of Jumbo AEAD implementation, using
+    Known Answer Tests submitted along with final round submission of Elephant
+    in NIST LWC
+
+    See https://csrc.nist.gov/projects/lightweight-cryptography/finalists
+    """
+    with open("jumbo.txt", "r") as fd:
+        while True:
+            cnt = fd.readline()
+            if not cnt:
+                # no more KATs remaining
+                break
+
+            key = fd.readline()
+            nonce = fd.readline()
+            pt = fd.readline()
+            ad = fd.readline()
+            ct = fd.readline()
+
+            # extract out required fields
+            cnt = int([i.strip() for i in cnt.split("=")][-1])
+            key = [i.strip() for i in key.split("=")][-1]
+            nonce = [i.strip() for i in nonce.split("=")][-1]
+            pt = [i.strip() for i in pt.split("=")][-1]
+            ad = [i.strip() for i in ad.split("=")][-1]
+            ct = [i.strip() for i in ct.split("=")][-1]
+
+            # 128 -bit secret key
+            key = int(f"0x{key}", base=16).to_bytes(len(key) >> 1, "big")
+            # 96 -bit public message nonce
+            nonce = int(f"0x{nonce}", base=16).to_bytes(len(nonce) >> 1, "big")
+            # plain text
+            pt = bytes(
+                [
+                    int(f"0x{pt[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(pt) >> 1)
+                ]
+            )
+            # associated data
+            ad = bytes(
+                [
+                    int(f"0x{ad[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(ad) >> 1)
+                ]
+            )
+            # cipher text + authentication tag ( expected )
+            ct = bytes(
+                [
+                    int(f"0x{ct[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(ct) >> 1)
+                ]
+            )
+
+            cipher, tag = elephant.jumbo_encrypt(key, nonce, ad, pt)
+            flag, text = elephant.jumbo_decrypt(key, nonce, tag, ad, cipher)
+
+            assert (
+                cipher + tag == ct
+            ), f"[Jumbo KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x${(cipher + tag).hex()} !"
+            assert (
+                pt == text and flag
+            ), f"[Jumbo KAT {cnt}] expected plain text 0x{pt.hex()}, found 0x{text.hex()} !"
+
+            # don't need this line, so discard
+            fd.readline()
+
+
 if __name__ == "__main__":
     print("Execute test cases using `pytest`")


### PR DESCRIPTION
Implements Jumbo authenticated encryption with associated data (AEAD), which uses `Spongent-π[176]` permutation as underlying primitive.